### PR TITLE
fix(ui): replace chai button with github icon

### DIFF
--- a/src/constants/help/instructions.tsx
+++ b/src/constants/help/instructions.tsx
@@ -1,6 +1,6 @@
 import { Board } from '@/components';
 import React from 'react';
-
+import { FaGithub } from 'react-icons/fa';
 
 const hiddenShapes: string[][][] = [
     [
@@ -134,7 +134,19 @@ export const instructions: readonly (string | JSX.Element)[][] = [
             Made with ❤️ by <a href="https://github.com/coder-zs-cse/" className='text-green-600 font-bold' target="_blank" rel="noopener noreferrer">Zubin Shah</a>
         </>,
         <>
-            Buy me a <a href="https://getmechai.vercel.app/link.html?vpa=www.zubinshah1886@okaxis&nm=ZubinShah&amt=100" className='text-green-600 font-bold' target="_blank" rel="noopener noreferrer">{" "}chai ☕</a>
+        <>
+    <>
+    <a
+        href="https://github.com/coder-zs-cse/Shabble"
+        className='text-green-600 font-bold inline-flex items-center gap-2'
+        target="_blank"
+        rel="noopener noreferrer"
+    >
+        <FaGithub size={29} />
+        GitHub
+    </a>
+</>
+</>
         </>
     ]
 ] as const;


### PR DESCRIPTION
Closes #5
What changed :
Removed the “Buy me a chai” link from the instructions section
Added a GitHub icon using `react-icons/fa`
Linked the icon to the official Shabble GitHub repository

Why :

This keeps the UI cleaner and makes the section more relevant by redirecting users directly to the project repository.

UI Changes:

Replaced text-based chai link with a GitHub icon

<img width="512" height="808" alt="Screenshot 2026-05-15 012123" src="https://github.com/user-attachments/assets/8738c78c-9d9e-41c0-afe6-ad671a9d09e4" />


