### PR TITLE
[FEATURE] Persisting numbers on guess mode

### DIFF
--- a/src/components/ui/tile/tile.tsx
+++ b/src/components/ui/tile/tile.tsx
@@ -87,7 +87,7 @@ function Tile({ className, tileContent, guessContent, onClick, gameStatus, incor
       })}
     >
       {isGuessModeHint ? (
-        <span className="opacity-50">{getTileContent()}</span>
+        <span className="opacity-15">{getTileContent()}</span>
       ) : (
         getTileContent()
       )}

--- a/src/components/ui/tile/tile.tsx
+++ b/src/components/ui/tile/tile.tsx
@@ -68,17 +68,19 @@ function Tile({ className, tileContent, guessContent, onClick, gameStatus, incor
     if (gameStatus === "tile-loading") {
       return tileContent ? tileContent : isLoading ? <TileLoader /> : '';
     }
-    if (["playing", "lost"].includes(gameStatus || "") && tileContent) return tileContent;
+    if (["playing", "lost", "guessing", "guess-loading"].includes(gameStatus || "") && tileContent) return tileContent;
     return '';
   };
+
+  const tileStatus = getTileStatus();
 
   return (
     <div
       onClick={handleTileClick}
       className={tile({
-        status: getTileStatus(),
+        status: tileStatus,
         gameComplete: ["won", "lost"].includes(gameStatus || ""),
-        className
+        className: `${className || ''} ${tileStatus === 'guess-empty' && tileContent ? '!text-green-800' : ''}`
       })}
     >
       {getTileContent()}

--- a/src/components/ui/tile/tile.tsx
+++ b/src/components/ui/tile/tile.tsx
@@ -75,6 +75,8 @@ function Tile({ className, tileContent, guessContent, onClick, gameStatus, incor
 
   const tileStatus = getTileStatus();
 
+  const isGuessModeHint = ["guessing", "guess-loading"].includes(gameStatus || "") && tileContent && tileContent !== 'X';
+
   return (
     <div
       onClick={handleTileClick}
@@ -84,7 +86,11 @@ function Tile({ className, tileContent, guessContent, onClick, gameStatus, incor
         className: `${className || ''} ${tileStatus === 'guess-empty' && tileContent ? '!text-green-800' : ''}`
       })}
     >
-      {getTileContent()}
+      {isGuessModeHint ? (
+        <span className="opacity-50">{getTileContent()}</span>
+      ) : (
+        getTileContent()
+      )}
     </div>
   )
 }

--- a/src/components/ui/tile/tile.tsx
+++ b/src/components/ui/tile/tile.tsx
@@ -14,17 +14,17 @@ interface TileProps {
 }
 
 const tile = tv({
-  base: "flex items-center justify-center rounded-md sm:rounded-xl md:rounded-xl font-bold text-2xl md:text-4xl text-white shadow-[inset_0_-4px_0_rgba(0,0,0,0.05)]",
+  base: "flex items-center justify-center rounded-md sm:rounded-xl md:rounded-xl font-bold text-2xl md:text-4xl shadow-[inset_0_-4px_0_rgba(0,0,0,0.05)]",
   variants: {
     status: {
-      "tile-empty": "bg-gray-200",
-      "tile-loading": "bg-yellow-400",
-      "tile-filled": "bg-yellow-400",
-      "guess-empty": "bg-green-200",
-      "guess-filled": "bg-green-600",
-      "guess-loading": "animate-guessLoading",
-      "guess-incorrect": "bg-red-600 animate-shake",
-      "won": "bg-green-600"
+      "tile-empty": "bg-gray-200 text-white",
+      "tile-loading": "bg-yellow-400 text-white",
+      "tile-filled": "bg-yellow-400 text-white",
+      "guess-empty": "bg-green-200 text-green-800",
+      "guess-filled": "bg-green-600 text-white",
+      "guess-loading": "animate-guessLoading text-white",
+      "guess-incorrect": "bg-red-600 animate-shake text-white",
+      "won": "bg-green-600 text-white"
     },
     gameComplete: {
       true: "cursor-not-allowed",
@@ -83,14 +83,12 @@ function Tile({ className, tileContent, guessContent, onClick, gameStatus, incor
       className={tile({
         status: tileStatus,
         gameComplete: ["won", "lost"].includes(gameStatus || ""),
-        className: `${className || ''} ${tileStatus === 'guess-empty' && tileContent ? '!text-green-800' : ''}`
+        className
       })}
     >
-      {isGuessModeHint ? (
-        <span className="opacity-15">{getTileContent()}</span>
-      ) : (
-        getTileContent()
-      )}
+      <span className={isGuessModeHint ? "opacity-15" : ""}>
+        {getTileContent()}
+      </span>
     </div>
   )
 }

--- a/src/components/ui/tile/tile.tsx
+++ b/src/components/ui/tile/tile.tsx
@@ -68,7 +68,8 @@ function Tile({ className, tileContent, guessContent, onClick, gameStatus, incor
     if (gameStatus === "tile-loading") {
       return tileContent ? tileContent : isLoading ? <TileLoader /> : '';
     }
-    if (["playing", "lost", "guessing", "guess-loading"].includes(gameStatus || "") && tileContent) return tileContent;
+    if (["playing", "lost"].includes(gameStatus || "") && tileContent) return tileContent;
+    if (["guessing", "guess-loading"].includes(gameStatus || "") && tileContent && tileContent !== 'X') return tileContent;
     return '';
   };
 

--- a/src/components/ui/tile/tile.tsx
+++ b/src/components/ui/tile/tile.tsx
@@ -20,8 +20,8 @@ const tile = tv({
       "tile-empty": "bg-gray-200 dark:bg-gray-800 text-white",
       "tile-loading": "bg-yellow-400 text-white",
       "tile-filled": "bg-yellow-400 dark:bg-yellow-500 text-white",
-      "guess-empty": "bg-green-200 text-green-800/15",
-      "guess-filled": "bg-green-600 text-white/15",
+      "guess-empty": "bg-green-200 text-green-800/50",
+      "guess-filled": "bg-green-600 text-white/30",
       "guess-loading": "animate-guessLoading text-white/15",
       "guess-incorrect": "bg-red-600 animate-shake text-white",
       "won": "bg-green-600 text-white"

--- a/src/components/ui/tile/tile.tsx
+++ b/src/components/ui/tile/tile.tsx
@@ -17,14 +17,14 @@ const tile = tv({
   base: "flex items-center justify-center rounded-md sm:rounded-xl md:rounded-xl font-bold text-2xl md:text-4xl shadow-[inset_0_-4px_0_rgba(0,0,0,0.05)]",
   variants: {
     status: {
-      "tile-empty": "bg-gray-200 dark:bg-gray-800",
-      "tile-loading": "bg-yellow-400",
-      "tile-filled": "bg-yellow-400 dark:bg-yellow-500",
-      "guess-empty": "bg-green-200",
-      "guess-filled": "bg-green-600",
-      "guess-loading": "animate-guessLoading",
-      "guess-incorrect": "bg-red-600 animate-shake",
-      "won": "bg-green-600"
+      "tile-empty": "bg-gray-200 dark:bg-gray-800 text-white",
+      "tile-loading": "bg-yellow-400 text-white",
+      "tile-filled": "bg-yellow-400 dark:bg-yellow-500 text-white",
+      "guess-empty": "bg-green-200 text-green-800/15",
+      "guess-filled": "bg-green-600 text-white/15",
+      "guess-loading": "animate-guessLoading text-white/15",
+      "guess-incorrect": "bg-red-600 animate-shake text-white",
+      "won": "bg-green-600 text-white"
     },
     gameComplete: {
       true: "",
@@ -75,8 +75,6 @@ function Tile({ className, tileContent, guessContent, onClick, gameStatus, incor
 
   const tileStatus = getTileStatus();
 
-  const isGuessModeHint = ["guessing", "guess-loading"].includes(gameStatus || "") && tileContent && tileContent !== 'X';
-
   return (
     <div
       onClick={handleTileClick}
@@ -86,9 +84,7 @@ function Tile({ className, tileContent, guessContent, onClick, gameStatus, incor
         className
       })}
     >
-      <span className={isGuessModeHint ? "opacity-15" : ""}>
-        {getTileContent()}
-      </span>
+      {getTileContent()}
     </div>
   )
 }


### PR DESCRIPTION
Related Issue #20 

## Description
Ensures that tile numbers remain visible when on guessing mode.
### Changes:
- State Management: Updated the helper function in Tile to retain and return tileContent during "guessing" and "guess-loading" game statuses.

- Performance Optimization: Cached the result of getTileStatus() into a local tileStatus constant to avoid redundant function calls during rendering.

- Styling: Added a conditional class utility to inject !text-green-800 when a tile is empty but contains valid content during a guess state, improving visual feedback. As instructed, the opacity have been decreased.

## Screenshots:

### Guess Mode

<img width="908" height="968" alt="image" src="https://github.com/user-attachments/assets/bc801dc2-08f2-4c6a-ae5a-f277724e337a" />

### On Submitting:
<img width="915" height="929" alt="image" src="https://github.com/user-attachments/assets/679ed824-15ed-43bd-9841-ff526f722944" />
