### PR TITLE
docs(help): remove duplicate grid example and clarify rule phrasing

### DIFF
--- a/src/constants/help/instructions.tsx
+++ b/src/constants/help/instructions.tsx
@@ -18,14 +18,8 @@ const hiddenShapes: string[][][] = [
         ["", "", "", "", "", ""],
         ["", "", "", "", "", ""]
     ],
-    [
-        ["", "", "", "", "X", ""],
-        ["", "", "", "X", "X", ""],
-        ["", "", "", "X", "", ""],
-        ["", "", "X", "X", "", ""],
-        ["", "", "", "", "", ""],
-        ["", "", "", "", "", ""]
-    ],
+    
+        
     [
         ["", "", "", "", "", "", ""],
         ["", "", "", "", "", "", ""],
@@ -89,7 +83,7 @@ export const instructions: readonly (string | JSX.Element)[][] = [
             </div>
         </>,
         <>
-            The number of tiles in the hidden shape is equal to the length of the board.
+            The hidden shape contains as many tiles as the grid's side dimension (e.g., a 5x5 board has a 5-tile shape).
         </>
     ],
     [


### PR DESCRIPTION
## Description
This PR addresses an issue in the "How to Play" instructional modal. It cleans up the layout and improves readability for new players by removing a duplicate grid example and rephrasing the core gameplay rules to be more intuitive.

## Changes Made
* **`src/constants/help/instructions.tsx`**: Removed the duplicate grid structure and streamlined the rule phrasing.

## Verification
* Verified the model's layout changes locally across various viewport sizes to ensure the text and grid images align perfectly and look crisp.
<img width="977" height="926" alt="Screenshot 2026-05-26 192708" src="https://github.com/user-attachments/assets/b9e1ea91-29f3-485d-9b4d-68f8e853adae" />


Closes #35 