### PR TITLE
feat: add OAuth, leaderboard, stats, account linking

### DIFF
--- a/app/api/auth/[...nextauth]/route.ts
+++ b/app/api/auth/[...nextauth]/route.ts
@@ -1,0 +1,3 @@
+import { handlers } from "@/auth";
+
+export const { GET, POST } = handlers;

--- a/app/api/leaderboard/route.ts
+++ b/app/api/leaderboard/route.ts
@@ -1,0 +1,12 @@
+import { NextResponse } from "next/server";
+import { getLeaderboard } from "@/services";
+
+export async function GET() {
+    try {
+        const users = await getLeaderboard();
+        return NextResponse.json({ users });
+    } catch (error) {
+        console.error("Error fetching leaderboard:", error);
+        return NextResponse.json({ error: "Failed to fetch leaderboard" }, { status: 500 });
+    }
+}

--- a/app/layout.tsx
+++ b/app/layout.tsx
@@ -1,5 +1,6 @@
 import type { Metadata } from "next";
 import { ToastContainer } from 'react-toastify';
+import { AuthSessionProvider } from "@/components/providers/session-provider";
 import "@/styles/globals.css";
 
 export const metadata: Metadata = {
@@ -18,8 +19,10 @@ export default function RootLayout({
   return (
     <html lang="en">
       <body>
-        <ToastContainer />
-        {children}
+        <AuthSessionProvider>
+          <ToastContainer />
+          {children}
+        </AuthSessionProvider>
       </body>
       {/* <script defer src="https://usa.kenyt.ai/botapp/ChatbotUI/dist/js/bot-loader.js" type="text/javascript" data-bot="188903092"></script> */}
       {/* <script defer src="https://www.kenyt.ai/botapp/ChatbotUI/dist/js/bot-loader.js" type="text/javascript" data-bot="111651938"></script> */}

--- a/app/login/page.tsx
+++ b/app/login/page.tsx
@@ -1,0 +1,54 @@
+'use client'
+import { signIn } from "next-auth/react"
+import { useState } from "react"
+import { Title, Text, Button, Divider } from "@/components"
+import { FcGoogle } from "react-icons/fc"
+
+export default function LoginPage() {
+    const [email, setEmail] = useState("")
+
+    return (
+        <div className="flex items-center justify-center w-full min-h-screen bg-gray-200">
+            <div className="flex flex-col gap-6 bg-white p-8 rounded-lg shadow-lg w-[90%] max-w-md">
+                <div className="flex flex-col gap-2 text-center">
+                    <Title title="Secure your stats with an account" className="!text-[20px] md:!text-[24px]" />
+                    <Text className="text-gray-500 text-sm">
+                        Use your email or social profile to create an account or to log in to an existing account. Your stats will be synced across all logged in devices :)
+                    </Text>
+                </div>
+
+                <div className="flex flex-col gap-3">
+                    <input
+                        type="email"
+                        placeholder="example@gmail.com"
+                        value={email}
+                        onChange={(e) => setEmail(e.target.value)}
+                        onKeyDown={(e) => e.key === 'Enter' && email && signIn("google", { callbackUrl: "/daily" }, { login_hint: email })}
+                        className="w-full h-[48px] px-4 border border-gray-200 rounded-[7px] md:rounded-[10px] text-sm outline-none focus:border-gray-400"
+                    />
+                    <Button
+                        disabled={!email}
+                        onClick={() => signIn("google", { callbackUrl: "/daily" }, { login_hint: email })}
+                        className="text-sm font-semibold tracking-wide"
+                    >
+                        CONTINUE
+                    </Button>
+                </div>
+
+                <div className="flex items-center gap-3">
+                    <Divider />
+                    <Text className="text-gray-400 text-sm whitespace-nowrap">— or —</Text>
+                    <Divider />
+                </div>
+
+                <Button
+                    onClick={() => signIn("google", { callbackUrl: "/daily" })}
+                    className="gap-2 text-sm font-semibold tracking-wide"
+                >
+                    <FcGoogle className="w-5 h-5" />
+                    CONTINUE WITH GOOGLE
+                </Button>
+            </div>
+        </div>
+    )
+}

--- a/middleware.ts
+++ b/middleware.ts
@@ -1,33 +1,45 @@
 import { NextResponse } from 'next/server'
 import type { NextRequest } from 'next/server'
+import { auth } from '@/auth'
 
 export async function middleware(request: NextRequest) {
     try {
-        // Skip middleware for non-API routes and new-user route
-        if (!request.nextUrl.pathname.startsWith('/api') || 
+        // Auth routes and new-user route bypass game-API middleware
+        if (request.nextUrl.pathname.startsWith('/api/auth') ||
             request.nextUrl.pathname === '/api/new-user') {
             return NextResponse.next()
         }
 
+        if (!request.nextUrl.pathname.startsWith('/api')) {
+            return NextResponse.next()
+        }
+
+        // Prefer authenticated session userId over anonymous header
+        const session = await auth()
+        if (session?.user?.id) {
+            const newRequest = new Request(request.url, {
+                method: request.method,
+                headers: new Headers(request.headers),
+                body: request.body
+            })
+            newRequest.headers.set('userId', session.user.id)
+            return NextResponse.rewrite(new URL(request.url), { request: newRequest })
+        }
+
         const userId = request.headers.get('userId')
-        const response = NextResponse.next()
-        
-        // If no userId in header or user doesn't exist, create new user
         if (!userId) {
             const newUserResponse = await fetch(`${request.nextUrl.origin}/api/new-user`, {
                 method: 'PUT',
             })
             const data = await newUserResponse.json()
-            
-            // Create a new request with the updated headers
+
             const newRequest = new Request(request.url, {
                 method: request.method,
                 headers: new Headers(request.headers),
                 body: request.body
             })
             newRequest.headers.set('userId', data.userId)
-            
-            // Create response from the new request
+
             const response = NextResponse.rewrite(new URL(request.url), {
                 request: newRequest
             })
@@ -35,7 +47,7 @@ export async function middleware(request: NextRequest) {
             return response
         }
 
-        return response
+        return NextResponse.next()
     } catch (error) {
         console.error('Error in middleware:', error)
         return NextResponse.next()

--- a/prisma/migrations/20260524000000_add_provider_country_leaderboard/migration.sql
+++ b/prisma/migrations/20260524000000_add_provider_country_leaderboard/migration.sql
@@ -1,0 +1,48 @@
+-- CreateTable: UserStats (separating stats from identity)
+CREATE TABLE "UserStats" (
+    "id" SERIAL NOT NULL,
+    "userId" TEXT NOT NULL,
+    "played" INTEGER NOT NULL DEFAULT 0,
+    "totalStars" INTEGER NOT NULL DEFAULT 0,
+    "currentStreak" INTEGER NOT NULL DEFAULT 0,
+    "bestStreak" INTEGER NOT NULL DEFAULT 0,
+    "starDistribution" INTEGER[] NOT NULL DEFAULT '{0,0,0,0,0,0}',
+    "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP,
+
+    CONSTRAINT "UserStats_pkey" PRIMARY KEY ("id")
+);
+
+-- CreateIndex: unique userId on UserStats
+CREATE UNIQUE INDEX "UserStats_userId_key" ON "UserStats"("userId");
+
+-- AddForeignKey: UserStats -> User
+ALTER TABLE "UserStats" ADD CONSTRAINT "UserStats_userId_fkey"
+    FOREIGN KEY ("userId") REFERENCES "User"("id") ON DELETE RESTRICT ON UPDATE CASCADE;
+
+-- Migrate existing stats from User into UserStats
+INSERT INTO "UserStats" ("userId", "played", "totalStars", "currentStreak", "bestStreak", "starDistribution", "updatedAt")
+SELECT "id", "played", "totalStars", "currentStreak", "bestStreak", "starDistribution", CURRENT_TIMESTAMP
+FROM "User";
+
+-- AlterTable: add identity columns to User
+ALTER TABLE "User"
+    ADD COLUMN "name"        TEXT,
+    ADD COLUMN "email"       TEXT,
+    ADD COLUMN "provider"    TEXT,
+    ADD COLUMN "providerId"  TEXT,
+    ADD COLUMN "countryCode" TEXT;
+
+-- CreateIndex: unique (provider, providerId) for OAuth upsert
+CREATE UNIQUE INDEX "User_provider_providerId_key" ON "User"("provider", "providerId");
+
+-- AlterTable: drop stats columns from User (now live in UserStats)
+ALTER TABLE "User"
+    DROP COLUMN "played",
+    DROP COLUMN "totalStars",
+    DROP COLUMN "currentStreak",
+    DROP COLUMN "bestStreak",
+    DROP COLUMN "starDistribution";
+
+-- AlterTable: add updatedAt to UserProgress
+ALTER TABLE "UserProgress"
+    ADD COLUMN "updatedAt" TIMESTAMP(3) NOT NULL DEFAULT CURRENT_TIMESTAMP;

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -10,7 +10,7 @@ generator client {
 
 datasource db {
   provider = "postgresql"
-  url      = env("POSTGRES_URL")
+  url      = env("DATABASE_URL")
 }
 
 model DailyPuzzle {
@@ -25,14 +25,29 @@ model DailyPuzzle {
 }
 
 model User {
-  id               String         @id
-  played           Int            @default(0)
-  totalStars       Int            @default(0)
-  currentStreak    Int            @default(0)
-  bestStreak       Int            @default(0)
-  starDistribution Int[]          @default([0, 0, 0, 0, 0, 0])
-  createdAt        DateTime       @default(now())
-  progress         UserProgress[]
+  id          String        @id
+  name        String?
+  email       String?
+  provider    String?
+  providerId  String?
+  countryCode String?
+  createdAt   DateTime      @default(now())
+  stats       UserStats?
+  progress    UserProgress[]
+
+  @@unique([provider, providerId])
+}
+
+model UserStats {
+  id               Int      @id @default(autoincrement())
+  userId           String   @unique
+  played           Int      @default(0)
+  totalStars       Int      @default(0)
+  currentStreak    Int      @default(0)
+  bestStreak       Int      @default(0)
+  starDistribution Int[]    @default([0, 0, 0, 0, 0, 0])
+  updatedAt        DateTime @updatedAt
+  user             User     @relation(fields: [userId], references: [id])
 }
 
 enum GameStatus {
@@ -50,6 +65,7 @@ model UserProgress {
   status            GameStatus  @default(playing)
   stars             Int?
   createdAt         DateTime    @default(now())
+  updatedAt         DateTime    @updatedAt
   user              User        @relation(fields: [userId], references: [id])
   puzzle            DailyPuzzle @relation(fields: [puzzleId], references: [id])
 

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -1,58 +1,56 @@
-
 import axios, {
     AxiosInstance,
     AxiosError,
     InternalAxiosRequestConfig,
-  } from "axios";
-  // import { getUserId } from "@/api/user";
-  import { envConfig } from "@/lib/config/envConfig";
+} from "axios";
+import { envConfig } from "@/lib/config/envConfig";
+import { getSession } from "next-auth/react";
 
-  const createAxiosInstance = (
+const createAxiosInstance = (
     baseURL: string,
     secure: boolean = false
-  ): AxiosInstance => {
+): AxiosInstance => {
 
     const instance = axios.create({
-      baseURL: baseURL,
-      headers: {
-        "Content-Type": "application/json",
-        Accept: "application/json",
-      },
+        baseURL: baseURL,
+        headers: {
+            "Content-Type": "application/json",
+            Accept: "application/json",
+        },
     });
-  
-    if (secure) {
-      instance.interceptors.request.use(
-        async (config: InternalAxiosRequestConfig) => {
-          try {
-            const userId = localStorage.getItem("userId");
-            if (userId) {
-                config.headers.set("userId", userId);
-            }
-          } catch (error) {
-            console.error("Failed to get userId:", error);
-          }
-          return config;
-        },
-        (error: AxiosError) => Promise.reject(error)
-      );
 
-      instance.interceptors.response.use(
-        (response) => {
-            const newUserId = response.headers['x-user-id'];
-            console.log("newUserId in response", newUserId)
-            if (newUserId) {
-                localStorage.setItem("userId", newUserId);
-            }
-            return response;
-        },
-        (error: AxiosError) => Promise.reject(error)
-    );
+    if (secure) {
+        instance.interceptors.request.use(
+            async (config: InternalAxiosRequestConfig) => {
+                try {
+                    // Prefer authenticated session userId over anonymous localStorage id
+                    const session = await getSession();
+                    const userId = session?.user?.id ?? localStorage.getItem("userId");
+                    if (userId) {
+                        config.headers.set("userId", userId);
+                    }
+                } catch (error) {
+                    console.error("Failed to get userId:", error);
+                }
+                return config;
+            },
+            (error: AxiosError) => Promise.reject(error)
+        );
+
+        instance.interceptors.response.use(
+            (response) => {
+                const newUserId = response.headers['x-user-id'];
+                if (newUserId) {
+                    localStorage.setItem("userId", newUserId);
+                }
+                return response;
+            },
+            (error: AxiosError) => Promise.reject(error)
+        );
     }
-  
+
     return instance;
-  };
-  
-  // Instances for BASE_URL
-  export const axiosSecure = createAxiosInstance(envConfig.BASE_URL!, true);
-  export const axiosOpen = createAxiosInstance(envConfig.BASE_URL!);
-  
+};
+
+export const axiosSecure = createAxiosInstance(envConfig.BASE_URL!, true);
+export const axiosOpen = createAxiosInstance(envConfig.BASE_URL!);

--- a/src/auth.ts
+++ b/src/auth.ts
@@ -1,0 +1,42 @@
+import NextAuth from "next-auth";
+import Google from "next-auth/providers/google";
+import { upsertGoogleUser } from "@/services";
+
+export const { handlers, signIn, signOut, auth } = NextAuth({
+    providers: [
+        Google({
+            clientId: process.env.GOOGLE_CLIENT_ID!,
+            clientSecret: process.env.GOOGLE_CLIENT_SECRET!,
+        }),
+    ],
+    secret: process.env.AUTH_SECRET,
+    callbacks: {
+        async signIn({ user, account }) {
+            if (account?.provider === "google" && account.providerAccountId) {
+                const dbUserId = await upsertGoogleUser({
+                    providerId: account.providerAccountId,
+                    name: user.name,
+                    email: user.email,
+                });
+                // Store our DB userId on the token
+                (user as typeof user & { dbUserId: string }).dbUserId = dbUserId;
+            }
+            return true;
+        },
+        async jwt({ token, user }) {
+            if (user && (user as typeof user & { dbUserId?: string }).dbUserId) {
+                token.dbUserId = (user as typeof user & { dbUserId: string }).dbUserId;
+            }
+            return token;
+        },
+        async session({ session, token }) {
+            if (token.dbUserId) {
+                session.user.id = token.dbUserId as string;
+            }
+            return session;
+        },
+    },
+    pages: {
+        signIn: "/login",
+    },
+});

--- a/src/components/daily/nav/leaderboard-tab.tsx
+++ b/src/components/daily/nav/leaderboard-tab.tsx
@@ -1,0 +1,64 @@
+'use client'
+import React, { useEffect, useState } from 'react'
+import { axiosOpen } from '@/api/axios'
+import { Loader } from '@/components'
+
+const MAX_LEADERBOARD_USERS = 10
+
+interface LeaderboardUser {
+    name: string | null
+    totalStars: number
+    played: number
+    bestStreak: number
+}
+
+export function LeaderboardTab() {
+    const [users, setUsers] = useState<LeaderboardUser[]>([])
+    const [loading, setLoading] = useState(true)
+    const [error, setError] = useState(false)
+
+    useEffect(() => {
+        axiosOpen.get('/leaderboard')
+            .then(res => setUsers(res.data.users.slice(0, MAX_LEADERBOARD_USERS)))
+            .catch(() => setError(true))
+            .finally(() => setLoading(false))
+    }, [])
+
+    if (loading) {
+        return (
+            <div className="flex justify-center items-center py-12">
+                <Loader />
+            </div>
+        )
+    }
+
+    if (error) {
+        return <p className="text-center text-sm text-gray-400 py-8">Failed to load leaderboard.</p>
+    }
+
+    if (users.length === 0) {
+        return <p className="text-center text-sm text-gray-400 py-8">No entries yet. Be the first to log in and play!</p>
+    }
+
+    return (
+        <div className="overflow-y-auto max-h-[calc(100vh-260px)] hide-scrollbar">
+            {users.map((user, index) => (
+                <div
+                    key={index}
+                    className="flex items-center justify-between py-3 border-b last:border-b-0 hover:bg-gray-50"
+                >
+                    <div className="flex items-center gap-3">
+                        <span className="w-6 text-center text-sm font-bold text-gray-400">{index + 1}</span>
+                        <span className="text-sm font-semibold truncate max-w-[160px]">
+                            {user.name ?? 'Anonymous'}
+                        </span>
+                    </div>
+                    <div className="flex items-center gap-1 text-sm font-semibold">
+                        <span className="text-yellow-500">★</span>
+                        <span>{user.totalStars}</span>
+                    </div>
+                </div>
+            ))}
+        </div>
+    )
+}

--- a/src/components/daily/nav/menu.tsx
+++ b/src/components/daily/nav/menu.tsx
@@ -1,10 +1,13 @@
 'use client'
 import { Divider, Title } from '@/components'
 import { useGameSettings } from '@/contexts'
-import React from 'react'
+import React, { useEffect, useState } from 'react'
 import { FaHeart, FaQuestion } from 'react-icons/fa'
 import { IoClose } from 'react-icons/io5'
 import { MdLeaderboard } from 'react-icons/md'
+import { MdLogin, MdLogout } from 'react-icons/md'
+import { useSession, signOut } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
 
 interface MenuProps {
     isOpen: boolean
@@ -22,6 +25,13 @@ const Menu: React.FC<MenuProps> = ({
     onShowHelp,
 }) => {
     const { settings } = useGameSettings();
+    const { data: session } = useSession();
+    const router = useRouter();
+    const [playerId, setPlayerId] = useState<string | null>(null);
+
+    useEffect(() => {
+        setPlayerId(localStorage.getItem("userId"));
+    }, []);
 
     const difficultyOptions = [
         { size: 5, label: 'EASY', level: '5 x 5', levelClassName: 'text-green-600' },
@@ -92,6 +102,37 @@ const Menu: React.FC<MenuProps> = ({
                                         </div>
                                     </div>
                                 ))}
+
+                                <Divider isVertical={false} className='my-2' />
+
+                                {session?.user ? (
+                                    <>
+                                        <div className='px-4 py-1 text-sm text-gray-500 uppercase tracking-wide truncate'>
+                                            {session.user.name || session.user.email}
+                                        </div>
+                                        <div
+                                            className='flex gap-1 items-center hover:bg-white rounded cursor-pointer'
+                                            onClick={() => signOut({ callbackUrl: '/daily' })}
+                                        >
+                                            <div className='pl-3'><MdLogout size={30} /></div>
+                                            <div className="w-full text-left p-3 text-[20px] uppercase font-bold">Log Out</div>
+                                        </div>
+                                    </>
+                                ) : (
+                                    <div
+                                        className='flex gap-1 items-center hover:bg-white rounded cursor-pointer'
+                                        onClick={() => { onClose(); router.push('/login'); }}
+                                    >
+                                        <div className='pl-3'><MdLogin size={30} /></div>
+                                        <div className="w-full text-left p-3 text-[20px] uppercase font-bold">Log In</div>
+                                    </div>
+                                )}
+
+                                {playerId && (
+                                    <div className='px-4 py-3 text-xs text-gray-400 uppercase tracking-wider text-center'>
+                                        PLAYER ID: {playerId}
+                                    </div>
+                                )}
                             </div>
                 </div>
                 </div>

--- a/src/components/daily/nav/statistics.tsx
+++ b/src/components/daily/nav/statistics.tsx
@@ -1,21 +1,19 @@
-import React from 'react'
+'use client'
+import React, { useState } from 'react'
 import { Title } from '@/components'
+import { useSession } from 'next-auth/react'
+import { useRouter } from 'next/navigation'
+import { LeaderboardTab } from './leaderboard-tab'
 
-// Subcomponents
 const StatBox = ({ label, value }: { label: string; value: number }) => (
   <div className="flex flex-col items-center justify-center py-4 border-b hover:bg-gray-100">
     <div className="flex items-center justify-center text-sm text-gray-600 uppercase tracking-wide w-full h-full text-center">{label}</div>
     <div className="text-2xl font-semibold text-center w-full h-full">{value}</div>
   </div>
-  // <div className="flex items-center justify-center">
-  //   <div className="text-xl text-gray-600 bg-gray-200 uppercase text-right tracking-wide w-full h-full">{label}</div>
-  //   <div className="text-2xl font-semibold w-full h-full pl-4">{value}</div>
-  // </div>
 )
 
 const StarBar = ({ stars, value, maxValue }: { stars: number; value: number; maxValue: number }) => {
   const percentage = maxValue > 0 ? (value / maxValue) * 100 : 0
-  
   return (
     <div className="flex items-center gap-2 mb-2">
       <div className="w-8 flex items-center justify-center">
@@ -24,7 +22,7 @@ const StarBar = ({ stars, value, maxValue }: { stars: number; value: number; max
       </div>
       <div className="flex-1 h-8 bg-gray-100 rounded-sm overflow-hidden">
         {value > 0 && (
-          <div 
+          <div
             className={`h-full ${stars === 0 ? 'bg-red-400' : 'bg-green-500'} transition-all duration-500`}
             style={{ width: `${percentage}%` }}
           />
@@ -48,57 +46,94 @@ interface StatisticsProps {
   setShowStatistics: (show: boolean) => void;
 }
 
-function Statistics({ statistics, setShowStatistics }: StatisticsProps) {
-  const maxDistribution = statistics.starDistribution.reduce((acc, curr) => acc + curr, 0)
+type Tab = 'statistics' | 'leaderboard'
 
-  const playerId = localStorage.getItem("userId")
+function Statistics({ statistics, setShowStatistics }: StatisticsProps) {
+  const [activeTab, setActiveTab] = useState<Tab>('statistics')
+  const maxDistribution = statistics.starDistribution.reduce((acc, curr) => acc + curr, 0)
+  const { data: session } = useSession()
+  const router = useRouter()
+
   return (
-    <div 
-      className="fixed inset-0 bg-black/50 flex items-center justify-center z-[10000]" 
+    <div
+      className="fixed inset-0 bg-black/50 flex items-center justify-center z-[10000]"
       onClick={() => setShowStatistics(false)}
     >
-      <div 
+      <div
         className="flex flex-col bg-white p-6 rounded-lg shadow-lg w-[90%] max-w-2xl"
         onClick={(e) => e.stopPropagation()}
       >
         {/* Header */}
         <div className="flex justify-between items-center mb-4">
           <Title title='STATISTICS' className='flex-1 text-center' />
-          <button 
-            onClick={() => setShowStatistics(false)}
-            className="text-gray-500 hover:text-gray-700"
-          >
+          <button onClick={() => setShowStatistics(false)} className="text-gray-500 hover:text-gray-700">
             ✕
           </button>
         </div>
 
-        {/* Stats Grid */}
-        <div className="grid grid-cols-2 gap-2 mb-8">
-          <StatBox label="Played" value={statistics.played} />
-          <StatBox label="Total Stars" value={statistics.totalStars} />
-          <StatBox label="Current Streak" value={statistics.currentStreak} />
-          <StatBox label="Best Streak" value={statistics.bestStreak} />
+        {/* Tabs */}
+        <div className="flex border-b mb-4">
+          <button
+            className={`flex-1 pb-2 text-sm font-semibold uppercase tracking-wide transition-colors ${activeTab === 'statistics' ? 'border-b-2 border-black text-black' : 'text-gray-400 hover:text-gray-600'}`}
+            onClick={() => setActiveTab('statistics')}
+          >
+            Statistics
+          </button>
+          <button
+            className={`flex-1 pb-2 text-sm font-semibold uppercase tracking-wide transition-colors ${activeTab === 'leaderboard' ? 'border-b-2 border-black text-black' : 'text-gray-400 hover:text-gray-600'}`}
+            onClick={() => setActiveTab('leaderboard')}
+          >
+            Leaderboard
+          </button>
         </div>
 
-        {/* Star Distribution */}
-        <div className="mb-8">
-          <Title title='STAR DISTRIBUTION' className='flex-1 text-center text-[20px] md:!text-[25px] font-normal mb-2' />
-          <div className="space-y-2">
-            {statistics.starDistribution.map((value, index) => (
-              <StarBar 
-                key={index}
-                stars={index}
-                value={value}
-                maxValue={maxDistribution}
-              />
-            ))}
-          </div>
-        </div>
+        {activeTab === 'statistics' ? (
+          <>
+            {/* Stats Grid — no overflow, fixed height */}
+            <div className="grid grid-cols-2 gap-2 mb-8">
+              <StatBox label="Played" value={statistics.played} />
+              <StatBox label="Total Stars" value={statistics.totalStars} />
+              <StatBox label="Current Streak" value={statistics.currentStreak} />
+              <StatBox label="Best Streak" value={statistics.bestStreak} />
+            </div>
 
-        {/* Player ID */}
-        <div className="text-center text-sm text-gray-500">
-          PLAYER ID: {playerId}
-        </div>
+            {/* Star Distribution */}
+            <div className="mb-6">
+              <Title title='STAR DISTRIBUTION' className='flex-1 text-center text-[20px] md:!text-[25px] font-normal mb-2' />
+              <div className="space-y-2">
+                {statistics.starDistribution.map((value, index) => (
+                  <StarBar key={index} stars={index} value={value} maxValue={maxDistribution} />
+                ))}
+              </div>
+            </div>
+
+            {/* Auth footer */}
+            {session?.user ? (
+              <div className="text-center text-sm text-gray-500">
+                Signed in as <span className="font-semibold">{session.user.name || session.user.email}</span>
+              </div>
+            ) : (
+              <div className="text-center text-sm text-gray-400">
+                Secure your stats with a free account{' '}
+                <button
+                  className="text-black underline font-medium"
+                  onClick={() => { setShowStatistics(false); router.push('/login'); }}
+                >
+                  Log in
+                </button>
+                {' or '}
+                <button
+                  className="text-black underline font-medium"
+                  onClick={() => { setShowStatistics(false); router.push('/login'); }}
+                >
+                  Sign up
+                </button>
+              </div>
+            )}
+          </>
+        ) : (
+          <LeaderboardTab />
+        )}
       </div>
     </div>
   )

--- a/src/components/providers/session-provider.tsx
+++ b/src/components/providers/session-provider.tsx
@@ -1,0 +1,6 @@
+'use client'
+import { SessionProvider } from "next-auth/react";
+
+export function AuthSessionProvider({ children }: { children: React.ReactNode }) {
+    return <SessionProvider>{children}</SessionProvider>;
+}

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -20,17 +20,21 @@ export {
 
 import {
     createUser,
+    upsertGoogleUser,
     incrementPlayedCount,
     updateStreak,
     updateStars,
-    getStatistics
+    getStatistics,
+    getLeaderboard
 } from "./user/user";
 
 export {
     createUser,
+    upsertGoogleUser,
     incrementPlayedCount,
     updateStreak,
     updateStars,
-    getStatistics
+    getStatistics,
+    getLeaderboard
 };
 

--- a/src/services/user/user.ts
+++ b/src/services/user/user.ts
@@ -7,7 +7,11 @@ export const createUser = async (): Promise<string> => {
     try {
         const userId = crypto.randomBytes(4).toString('hex').toUpperCase();
         await prisma.user.create({
-            data: { id: userId, createdAt: new Date() }
+            data: {
+                id: userId,
+                createdAt: new Date(),
+                stats: { create: {} }
+            }
         });
         return userId;
     } catch (error) {
@@ -16,29 +20,61 @@ export const createUser = async (): Promise<string> => {
     }
 }
 
+export const upsertGoogleUser = async ({
+    providerId,
+    name,
+    email,
+}: {
+    providerId: string;
+    name?: string | null;
+    email?: string | null;
+}): Promise<string> => {
+    try {
+        const existing = await prisma.user.findUnique({
+            where: { provider_providerId: { provider: 'google', providerId } }
+        });
+        if (existing) return existing.id;
+
+        const userId = crypto.randomBytes(4).toString('hex').toUpperCase();
+        await prisma.user.create({
+            data: {
+                id: userId,
+                provider: 'google',
+                providerId,
+                name: name ?? null,
+                email: email ?? null,
+                stats: { create: {} }
+            }
+        });
+        return userId;
+    } catch (error) {
+        console.error('Error upserting Google user:', error);
+        throw error;
+    }
+}
+
 export const getStatistics = async (userId: string): Promise<StatisticsProps> => {
     try {
-        const user = await prisma.user.findUnique({
-            where: { id: userId },
-            select: { played: true, totalStars: true, currentStreak: true, bestStreak: true, starDistribution: true }
+        const stats = await prisma.userStats.findUnique({
+            where: { userId }
         });
-        const statistics: StatisticsProps = {
-            played: user?.played || 0,
-            totalStars: user?.totalStars || 0,
-            currentStreak: user?.currentStreak || 0,
-            bestStreak: user?.bestStreak || 0,
-            starDistribution: user?.starDistribution || Array(MAX_STARS + 1).fill(0)
+        return {
+            played: stats?.played ?? 0,
+            totalStars: stats?.totalStars ?? 0,
+            currentStreak: stats?.currentStreak ?? 0,
+            bestStreak: stats?.bestStreak ?? 0,
+            starDistribution: stats?.starDistribution ?? Array(MAX_STARS + 1).fill(0)
         };
-        return statistics;
     } catch (error) {
         console.error('Error getting statistics:', error);
         throw error;
     }
 }
+
 export const incrementPlayedCount = async (userId: string): Promise<void> => {
     try {
-        await prisma.user.update({
-            where: { id: userId },
+        await prisma.userStats.update({
+            where: { userId },
             data: { played: { increment: 1 } }
         });
     } catch (error) {
@@ -49,22 +85,19 @@ export const incrementPlayedCount = async (userId: string): Promise<void> => {
 
 export const updateStreak = async (userId: string, won: boolean): Promise<void> => {
     try {
-        const user = await prisma.user.findUnique({
-            where: { id: userId },
+        const stats = await prisma.userStats.findUnique({
+            where: { userId },
             select: { currentStreak: true, bestStreak: true }
         });
 
-        if (!user) throw new Error('User not found');
+        if (!stats) throw new Error('UserStats not found');
 
-        const newCurrentStreak = won ? user.currentStreak + 1 : 0;
-        const newBestStreak = Math.max(user.bestStreak, newCurrentStreak);
+        const newCurrentStreak = won ? stats.currentStreak + 1 : 0;
+        const newBestStreak = Math.max(stats.bestStreak, newCurrentStreak);
 
-        await prisma.user.update({
-            where: { id: userId },
-            data: {
-                currentStreak: newCurrentStreak,
-                bestStreak: newBestStreak
-            }
+        await prisma.userStats.update({
+            where: { userId },
+            data: { currentStreak: newCurrentStreak, bestStreak: newBestStreak }
         });
     } catch (error) {
         console.error('Error updating streak:', error);
@@ -78,18 +111,18 @@ export const updateStars = async (userId: string, stars: number): Promise<void> 
             throw new Error('Stars must be between 0 and 5');
         }
 
-        const user = await prisma.user.findUnique({
-            where: { id: userId },
+        const stats = await prisma.userStats.findUnique({
+            where: { userId },
             select: { starDistribution: true }
         });
 
-        if (!user) throw new Error('User not found');
+        if (!stats) throw new Error('UserStats not found');
 
-        const newDistribution = [...user.starDistribution];
+        const newDistribution = [...stats.starDistribution];
         newDistribution[stars]++;
 
-        await prisma.user.update({
-            where: { id: userId },
+        await prisma.userStats.update({
+            where: { userId },
             data: {
                 totalStars: { increment: stars },
                 starDistribution: newDistribution
@@ -97,6 +130,32 @@ export const updateStars = async (userId: string, stars: number): Promise<void> 
         });
     } catch (error) {
         console.error('Error updating stars:', error);
+        throw error;
+    }
+}
+
+export const getLeaderboard = async (): Promise<{ name: string | null; totalStars: number; played: number; bestStreak: number }[]> => {
+    try {
+        const MAX_LEADERBOARD_USERS = 10;
+        const rows = await prisma.userStats.findMany({
+            where: { user: { provider: { not: null } } },
+            orderBy: { totalStars: 'desc' },
+            take: MAX_LEADERBOARD_USERS,
+            select: {
+                totalStars: true,
+                played: true,
+                bestStreak: true,
+                user: { select: { name: true } }
+            }
+        });
+        return rows.map(r => ({
+            name: r.user.name,
+            totalStars: r.totalStars,
+            played: r.played,
+            bestStreak: r.bestStreak
+        }));
+    } catch (error) {
+        console.error('Error fetching leaderboard:', error);
         throw error;
     }
 }

--- a/src/types/next-auth.d.ts
+++ b/src/types/next-auth.d.ts
@@ -1,0 +1,12 @@
+import "next-auth";
+
+declare module "next-auth" {
+    interface Session {
+        user: {
+            id: string;
+            name?: string | null;
+            email?: string | null;
+            image?: string | null;
+        };
+    }
+}


### PR DESCRIPTION
Closes #39  

This PR implements Google OAuth login, cross-device stat syncing, a public leaderboard, and a redesigned Statistics modal: following the interface pattern of games like `wafflegame.net` as suggested. Tried my best to replicate functionality.

---

## Changes

### Authentication
- Integrated `NextAuth` with Google OAuth provider
- New `/login` page: email input (for previous user) and a "Continue with Google" button
- `SessionProvider` added to root layout

### Database schema
- Split `User` model into identity (`name`, `email`, `provider`, `providerId`, `countryCode`) and a new `UserStats` model (`played`, `totalStars`, `currentStreak`, `bestStreak`, `starDistribution`) : separated as discussed, need review
- `upsertGoogleUser` checks if a user (google user) already exists using (`provider`, `providerId`). If the user exists, it returns the existing user; otherwise, it creates a new one. This prevents duplicate accounts when the same user logs in again. (Running it multiple times does not create duplicates or break anything)

### Leaderboard
- New `GET /api/leaderboard` endpoint returns top 10 authenticated users ordered by `totalStars` (anonymous users are not included)
- `MAX_LEADERBOARD_USERS` currently at 10 (as discussed) 
 
### Statistics modal
-  (Statistics + Leaderboard) tabs in the same page
- Statistics tab- non-scrollable, preserves existing `StatBox` + `StarBar` design. This tab shows "Secure your stats with a free account. Log in or Sign up" footer for guests --> shows signed-in name for authenticated users
- Leaderboard tab- scrollable only when entries exceed viewport height, capped at 10 users; ranked by total stars

### Menu
- Log In item added at the bottom for guests --> navigates to `/login`
- Log Out item + user display name shown for authenticated users
- Persistent `PLAYER ID` footer in all states

---

## Test plan

- [ ] `PUT /api/new-user` creates a `User` row (identity only) + a `UserStats` row with zero stats
- [ ] `GET /api/puzzle/status` reads stats from `UserStats`, not `User`
- [ ] Menu --> Log In --> `/login` page renders with email input and Google button
- [ ] Email input + Continue: Google OAuth opens with email pre-filled via `login_hint`
- [ ] Continue with Google: full OAuth flow completes, redirects to `/daily`
- [ ] After login, menu shows user name + Log Out; PLAYER ID still visible
- [ ] Log Out --> anonymous mode restored, new localStorage ID on next API call
- [ ] `GET /api/leaderboard` returns only authenticated users, ordered by `totalStars` desc
- [ ] Statistics modal --> Statistics tab: no scroll, "Secure your stats" footer for guests
- [ ] Statistics modal -->  Leaderboard tab: scrollable list, max 10 entries 
- [ ] Re-login with same Google account returns the same DB user ID 

Looking forward to get my code reviewed