### PR TITLE
feat: show reset dialog box when user not found in DB

### DIFF
--- a/app/api/puzzle/check/route.ts
+++ b/app/api/puzzle/check/route.ts
@@ -1,5 +1,5 @@
 import { validateGuessCheckParams } from "@/lib";
-import { checkGuess, getCurrentBoard, getStatistics, updateUserProgress } from "@/services";
+import { checkGuess, getCurrentBoard, getStatistics, updateUserProgress, validateUser } from "@/services";
 import { checkGuessResponse } from "@/types";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -10,6 +10,11 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         const { isValid, errors, data } = validateGuessCheckParams(await request.json(), userId);
         if (!isValid || !data) {
             return NextResponse.json({ errors }, { status: 400 });
+        }
+
+        const userExists = await validateUser(data.userId!);
+        if (!userExists) {
+            return NextResponse.json({ error: "USER_NOT_FOUND" }, { status: 404 });
         }
 
         const { puzzleId, guess } = data;

--- a/app/api/puzzle/hint/route.ts
+++ b/app/api/puzzle/hint/route.ts
@@ -1,4 +1,4 @@
-import { getAdjacentCount, getCurrentBoard, updateUserProgress } from "@/services";
+import { getAdjacentCount, getCurrentBoard, updateUserProgress, validateUser } from "@/services";
 import { NextResponse } from "next/server";
 import { validateHintParams } from "@/lib";
 import { getHintResponse } from "@/types/api/daily-api";
@@ -12,6 +12,12 @@ export async function GET(request: Request): Promise<NextResponse> {
         if (!isValid || !data) {
             return NextResponse.json({ errors }, { status: 400 });
         }
+
+        const userExists = await validateUser(data.userId!);
+        if (!userExists) {
+            return NextResponse.json({ error: "USER_NOT_FOUND" }, { status: 404 });
+        }
+
         const { puzzleId, x, y } = data;
 
         const currentBoard = await getCurrentBoard({ puzzleId });

--- a/app/api/puzzle/status/route.ts
+++ b/app/api/puzzle/status/route.ts
@@ -1,5 +1,5 @@
 import { validateStatusParams } from "@/lib";
-import { getGameStatus } from "@/services";
+import { getGameStatus, validateUser } from "@/services";
 import { GameStatusResponse } from "@/types";
 import { NextRequest, NextResponse } from "next/server";
 
@@ -11,6 +11,11 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
         const { isValid, errors, data } = validateStatusParams(searchParams, userId);
         if (!isValid || !data) {
             return NextResponse.json({ errors }, { status: 400 });
+        }
+
+        const userExists = await validateUser(data.userId!);
+        if (!userExists) {
+            return NextResponse.json({ error: "USER_NOT_FOUND" }, { status: 404 });
         }
 
         const { boardSize, date } = data;

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -45,7 +45,12 @@ import axios, {
             }
             return response;
         },
-        (error: AxiosError) => Promise.reject(error)
+        (error: AxiosError) => {
+            if (error.response?.status === 404 && (error.response?.data as { error?: string })?.error === "USER_NOT_FOUND") {
+                return Promise.reject(new Error("USER_NOT_FOUND"));
+            }
+            return Promise.reject(error);
+        }
     );
     }
   

--- a/src/components/daily/daily.tsx
+++ b/src/components/daily/daily.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Loader } from '@/components'
 import { useGameSettings } from '@/contexts'
 import {
@@ -10,9 +10,10 @@ import {
 } from './game'
 import { useGameLogic } from '@/hooks'
 import { toast } from 'react-toastify'
+import UserResetDialog from '@/components/ui/dialog/user-reset-dialog'
 
 function Daily() {
-    const { settings, isLoading, error } = useGameSettings();
+    const { settings, isLoading, error, userNotFound } = useGameSettings();
     const {
         showHelp,
         showStatistics,
@@ -23,12 +24,16 @@ function Daily() {
         setShowStatistics
     } = useGameLogic();
 
+    useEffect(() => {
+        if (error) {
+            toast.error("Database is inactive, please ask developer to activate it");
+        }
+    }, [error]);
+
     console.log("settings in daily", settings)
-    if(error){
-        toast.error("Database is inactive, please ask developer to activate it");
-    }
     return (
         <div className='relative flex flex-col items-center w-full h-full overflow-hidden'>
+            {userNotFound && <UserResetDialog />}
             <GameHeader
                 showHelp={showHelp}
                 showStatistics={showStatistics}

--- a/src/components/ui/dialog/user-reset-dialog.tsx
+++ b/src/components/ui/dialog/user-reset-dialog.tsx
@@ -1,0 +1,28 @@
+'use client'
+import React from 'react'
+import Button from '../button/button'
+
+function UserResetDialog() {
+    const handleReset = () => {
+        localStorage.removeItem('userId');
+        window.location.reload();
+    };
+
+    return (
+        <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
+            <div className='bg-white rounded-xl p-6 mx-4 max-w-sm w-full flex flex-col gap-4 shadow-xl'>
+                <div className='flex flex-col gap-1'>
+                    <h2 className='text-lg font-semibold text-black'>Account not found</h2>
+                    <p className='text-sm text-gray-500'>
+                        Your saved account could not be found. Reset to start fresh with a new account.
+                    </p>
+                </div>
+                <Button onClick={handleReset}>
+                    Reset
+                </Button>
+            </div>
+        </div>
+    )
+}
+
+export default UserResetDialog

--- a/src/components/ui/dialog/user-reset-dialog.tsx
+++ b/src/components/ui/dialog/user-reset-dialog.tsx
@@ -1,5 +1,6 @@
 'use client'
 import React from 'react'
+import Title from '../title/title'
 import Button from '../button/button'
 
 function UserResetDialog() {
@@ -9,16 +10,24 @@ function UserResetDialog() {
     };
 
     return (
-        <div className='fixed inset-0 z-50 flex items-center justify-center bg-black/50'>
-            <div className='bg-white rounded-xl p-6 mx-4 max-w-sm w-full flex flex-col gap-4 shadow-xl'>
-                <div className='flex flex-col gap-1'>
-                    <h2 className='text-lg font-semibold text-black'>Account not found</h2>
-                    <p className='text-sm text-gray-500'>
-                        Your saved account could not be found. Reset to start fresh with a new account.
+        <div className="fixed inset-0 bg-black/50 flex items-center justify-center z-[10000]">
+            <div className="flex flex-col bg-white p-6 rounded-lg shadow-lg w-[90%] max-w-sm gap-4">
+
+                <div className="flex items-center justify-center gap-2">
+                    <div className="w-6 h-6 rounded-md bg-yellow-400 shadow-[inset_0_-3px_0_rgba(0,0,0,0.1)]" />
+                    <div className="w-6 h-6 rounded-md bg-yellow-400 shadow-[inset_0_-3px_0_rgba(0,0,0,0.1)]" />
+                    <div className="w-6 h-6 rounded-md bg-yellow-400 shadow-[inset_0_-3px_0_rgba(0,0,0,0.1)]" />
+                </div>
+
+                <div className="flex flex-col items-center gap-1 text-center">
+                    <Title title="ACCOUNT NOT FOUND" className="text-red-700 !text-xl md:!text-2xl" />
+                    <p className="text-sm text-gray-500">
+                        Your saved account no longer exists. Reset to start fresh with a new account.
                     </p>
                 </div>
+
                 <Button onClick={handleReset}>
-                    Reset
+                    RESET
                 </Button>
             </div>
         </div>

--- a/src/contexts/puzzle/game-settings-context.tsx
+++ b/src/contexts/puzzle/game-settings-context.tsx
@@ -9,6 +9,7 @@ interface GameSettingsContextType {
     settings: GameSettings;
     isLoading: boolean;
     error: Error | null;
+    userNotFound: boolean;
     updateSettings: (updates: Partial<GameSettings>) => void;
     takeHint: (x: number, y: number) => Promise<boolean>;
     makeGuess: () => Promise<{ success: boolean; won: boolean; }>;
@@ -40,6 +41,7 @@ export function GameSettingsProvider({ children }: { children: React.ReactNode }
     const [loadingCoordinates, setLoadingCoordinates] = useState<{ x: number; y: number } | undefined>(undefined);
     const [isLoading, setIsLoading] = useState(false);
     const [error, setError] = useState<Error | null>(null);
+    const [userNotFound, setUserNotFound] = useState(false);
 
     console.log("settings", settings);
     useEffect(() => {
@@ -67,6 +69,10 @@ export function GameSettingsProvider({ children }: { children: React.ReactNode }
                 }
                 
             } catch (err) {
+                if (err instanceof Error && err.message === "USER_NOT_FOUND") {
+                    setUserNotFound(true);
+                    return;
+                }
                 setError(err instanceof Error ? err : new Error('Failed to fetch game settings'));
             } finally {
                 setIsLoading(false);
@@ -93,7 +99,9 @@ export function GameSettingsProvider({ children }: { children: React.ReactNode }
             return true;
         } catch (error) {
             console.error('Error fetching hint:', error);
-            // updateSettings({ hints: settings.hints - 1 });
+            if (error instanceof Error && error.message === "USER_NOT_FOUND") {
+                setUserNotFound(true);
+            }
             return false;
         } finally {
             setLoadingCoordinates(undefined);
@@ -130,6 +138,9 @@ export function GameSettingsProvider({ children }: { children: React.ReactNode }
             return { success: true, won: false };
         } catch (error) {
             console.error('Error checking guess:', error);
+            if (error instanceof Error && error.message === "USER_NOT_FOUND") {
+                setUserNotFound(true);
+            }
             return { success: false, won: false };
         }
     };
@@ -144,6 +155,7 @@ export function GameSettingsProvider({ children }: { children: React.ReactNode }
         settings,
         isLoading,
         error,
+        userNotFound,
         updateSettings,
         takeHint,
         makeGuess,

--- a/src/services/index.ts
+++ b/src/services/index.ts
@@ -23,7 +23,8 @@ import {
     incrementPlayedCount,
     updateStreak,
     updateStars,
-    getStatistics
+    getStatistics,
+    validateUser
 } from "./user/user";
 
 export {
@@ -31,6 +32,7 @@ export {
     incrementPlayedCount,
     updateStreak,
     updateStars,
-    getStatistics
+    getStatistics,
+    validateUser
 };
 

--- a/src/services/user/user.ts
+++ b/src/services/user/user.ts
@@ -35,6 +35,11 @@ export const getStatistics = async (userId: string): Promise<StatisticsProps> =>
         throw error;
     }
 }
+export const validateUser = async (userId: string): Promise<boolean> => {
+    const user = await prisma.user.findUnique({ where: { id: userId }, select: { id: true } });
+    return !!user;
+}
+
 export const incrementPlayedCount = async (userId: string): Promise<void> => {
     try {
         await prisma.user.update({


### PR DESCRIPTION
# Changes

### Backend

- Added `validateUser()` helper function in `src/services/user/user.ts` that checks DB if user exists
- All puzzle API routes (`/status`, `/hint`, `/check`) now call `validateUser` before processing and returns `404 { error: "USER_NOT_FOUND" }` if not found

### Frontend

- Axios response interceptor maps `404 USER_NOT_FOUND` to regular  `Error("USER_NOT_FOUND")` so we can differentiate errors
- New `UserResetDialog` component overlays the game with an "Account not found" message and a Reset button, clicking it removes `userId` from `localStorage` and reloads the page
- Fixed a pre existing bug:  `toast.error` was being called during render in `Daily` page; lifted it to a `useEffect`

---
## How to test/ Testing screenshots

Insert a fakeuser with a `userId` in the console.
<img width="919" height="359" alt="Screenshot from 2026-05-27 13-13-26" src="https://github.com/user-attachments/assets/f74d1e14-6ff7-4d9c-8f17-4115dbd7df03" />

Reload the `/daily` page and the reset dialog should appear. Click on `Reset` here.
<img width="768" height="826" alt="Screenshot from 2026-05-27 13-10-03" src="https://github.com/user-attachments/assets/bc90d893-3b73-4b6f-8dd0-6f67f6810b0f" />

`localStorage.userId` is cleared in the local storage
<img width="919" height="359" alt="Screenshot from 2026-05-27 13-13-42" src="https://github.com/user-attachments/assets/4ec16296-4a00-4dfd-9402-ce4d92f60d0b" />


Closes #37 