### PR TITLE
feat: standardise api error response

### DIFF
--- a/app/api/new-user/route.ts
+++ b/app/api/new-user/route.ts
@@ -1,15 +1,16 @@
 import { NextResponse } from "next/server";
 import { createUser } from "@/services";
-
+import { ApiResponse } from "@/types";
+import { ERROR_CODES, ERROR_MESSAGES } from "@/constants";
 
 export async function PUT(): Promise<NextResponse> {
     try {
         const userId = await createUser();
-        return NextResponse.json({ userId });
+        return NextResponse.json<ApiResponse<{ userId: string }>>({ data: { userId } });
     } catch (error) {
         console.error('Error creating user:', error);
-        return NextResponse.json(
-            { error: 'Failed to create user' },
+        return NextResponse.json<ApiResponse<null>>(
+            { data: null, error: { code: ERROR_CODES.USER_CREATION_FAILED, message: ERROR_MESSAGES[ERROR_CODES.USER_CREATION_FAILED] } },
             { status: 500 }
         );
     }

--- a/app/api/puzzle/check/route.ts
+++ b/app/api/puzzle/check/route.ts
@@ -1,6 +1,7 @@
 import { validateGuessCheckParams } from "@/lib";
 import { checkGuess, getCurrentBoard, getStatistics, updateUserProgress } from "@/services";
-import { checkGuessResponse } from "@/types";
+import { ApiResponse, checkGuessResponse } from "@/types";
+import { ERROR_CODES, ERROR_MESSAGES } from "@/constants";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function POST(request: NextRequest): Promise<NextResponse> {
@@ -9,7 +10,10 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
 
         const { isValid, errors, data } = validateGuessCheckParams(await request.json(), userId);
         if (!isValid || !data) {
-            return NextResponse.json({ errors }, { status: 400 });
+            return NextResponse.json<ApiResponse<null>>(
+                { data: null, error: { code: ERROR_CODES.VALIDATION_ERROR, message: errors?.join("; ") ?? ERROR_MESSAGES[ERROR_CODES.VALIDATION_ERROR] } },
+                { status: 400 }
+            );
         }
 
         const { puzzleId, guess } = data;
@@ -18,9 +22,16 @@ export async function POST(request: NextRequest): Promise<NextResponse> {
         const isCorrect = checkGuess(currentBoard.board as { x: number, y: number }[], guess);
         const updatedUserProgress = await updateUserProgress({ userId: data.userId!, boardSize: currentBoard.boardSize, puzzleId: currentBoard.id, status: isCorrect ? 'CORRECT' : 'WRONG' });
         const statistics = await getStatistics(userId!);
-        return NextResponse.json<checkGuessResponse>({ isCorrect, hintCount: updatedUserProgress.hintCount, gameStatus: updatedUserProgress.status, stars: updatedUserProgress.stars || undefined, statistics}, { status: 200 });
+
+        return NextResponse.json<ApiResponse<checkGuessResponse>>(
+            { data: { isCorrect, hintCount: updatedUserProgress.hintCount, gameStatus: updatedUserProgress.status, stars: updatedUserProgress.stars || undefined, statistics } },
+            { status: 200 }
+        );
     } catch (error) {
         console.error("Error checking guess:", error);
-        return NextResponse.json({ error: "Error checking guess" }, { status: 500 });
+        return NextResponse.json<ApiResponse<null>>(
+            { data: null, error: { code: ERROR_CODES.INTERNAL_SERVER_ERROR, message: ERROR_MESSAGES[ERROR_CODES.INTERNAL_SERVER_ERROR] } },
+            { status: 500 }
+        );
     }
 }

--- a/app/api/puzzle/hint/route.ts
+++ b/app/api/puzzle/hint/route.ts
@@ -1,7 +1,8 @@
 import { getAdjacentCount, getCurrentBoard, updateUserProgress } from "@/services";
 import { NextResponse } from "next/server";
 import { validateHintParams } from "@/lib";
-import { getHintResponse } from "@/types/api/daily-api";
+import { ApiResponse, getHintResponse } from "@/types/api/daily-api";
+import { ERROR_CODES, ERROR_MESSAGES } from "@/constants";
 
 export async function GET(request: Request): Promise<NextResponse> {
     try {
@@ -10,21 +11,27 @@ export async function GET(request: Request): Promise<NextResponse> {
 
         const { isValid, errors, data } = validateHintParams(searchParams, userId);
         if (!isValid || !data) {
-            return NextResponse.json({ errors }, { status: 400 });
+            return NextResponse.json<ApiResponse<null>>(
+                { data: null, error: { code: ERROR_CODES.VALIDATION_ERROR, message: errors?.join("; ") ?? ERROR_MESSAGES[ERROR_CODES.VALIDATION_ERROR] } },
+                { status: 400 }
+            );
         }
+
         const { puzzleId, x, y } = data;
 
         const currentBoard = await getCurrentBoard({ puzzleId });
-        console.log("Current board in hint",currentBoard)
+        console.log("Current board in hint", currentBoard);
         const board = currentBoard.board as { x: number, y: number }[];
 
         const adjacentCount = getAdjacentCount(board, currentBoard.boardSize, x, y);
         const updatedUserProgress = await updateUserProgress({ userId: data.userId!, puzzleId: currentBoard.id, boardSize: currentBoard.boardSize, hint: { x, y, c: adjacentCount }, status: 'playing' });
 
-        return NextResponse.json<getHintResponse>({ adjacentCount, hintCount: updatedUserProgress.hintCount });
+        return NextResponse.json<ApiResponse<getHintResponse>>({ data: { adjacentCount, hintCount: updatedUserProgress.hintCount } });
     } catch (error) {
         console.error("Error fetching hint:", error);
-        return NextResponse.json({ error: "Error fetching hint" }, { status: 500 });
+        return NextResponse.json<ApiResponse<null>>(
+            { data: null, error: { code: ERROR_CODES.INTERNAL_SERVER_ERROR, message: ERROR_MESSAGES[ERROR_CODES.INTERNAL_SERVER_ERROR] } },
+            { status: 500 }
+        );
     }
-
 }

--- a/app/api/puzzle/status/route.ts
+++ b/app/api/puzzle/status/route.ts
@@ -1,6 +1,7 @@
 import { validateStatusParams } from "@/lib";
 import { getGameStatus } from "@/services";
-import { GameStatusResponse } from "@/types";
+import { ApiResponse, GameStatusResponse } from "@/types";
+import { ERROR_CODES, ERROR_MESSAGES } from "@/constants";
 import { NextRequest, NextResponse } from "next/server";
 
 export async function GET(request: NextRequest): Promise<NextResponse> {
@@ -10,16 +11,22 @@ export async function GET(request: NextRequest): Promise<NextResponse> {
 
         const { isValid, errors, data } = validateStatusParams(searchParams, userId);
         if (!isValid || !data) {
-            return NextResponse.json({ errors }, { status: 400 });
+            return NextResponse.json<ApiResponse<null>>(
+                { data: null, error: { code: ERROR_CODES.VALIDATION_ERROR, message: errors?.join("; ") ?? ERROR_MESSAGES[ERROR_CODES.VALIDATION_ERROR] } },
+                { status: 400 }
+            );
         }
 
         const { boardSize, date } = data;
 
         const status = await getGameStatus(date, boardSize, userId!);
 
-        return NextResponse.json<GameStatusResponse>(status);
+        return NextResponse.json<ApiResponse<GameStatusResponse>>({ data: status });
     } catch (error) {
         console.error("Error fetching status:", error);
-        return NextResponse.json({ error: "Error fetching status" }, { status: 500 });
+        return NextResponse.json<ApiResponse<null>>(
+            { data: null, error: { code: ERROR_CODES.INTERNAL_SERVER_ERROR, message: ERROR_MESSAGES[ERROR_CODES.INTERNAL_SERVER_ERROR] } },
+            { status: 500 }
+        );
     }
 }

--- a/src/api/axios.ts
+++ b/src/api/axios.ts
@@ -6,6 +6,8 @@ import axios, {
   } from "axios";
   // import { getUserId } from "@/api/user";
   import { envConfig } from "@/lib/config/envConfig";
+  import { ERROR_CODES } from "@/constants";
+  import { ApiResponse } from "@/types";
 
   const createAxiosInstance = (
     baseURL: string,
@@ -45,7 +47,13 @@ import axios, {
             }
             return response;
         },
-        (error: AxiosError) => Promise.reject(error)
+        (error: AxiosError) => {
+            const apiError = (error.response?.data as ApiResponse<unknown>)?.error;
+            if (error.response?.status === 404 && apiError?.code === ERROR_CODES.USER_NOT_FOUND) {
+                return Promise.reject(new Error("USER_NOT_FOUND"));
+            }
+            return Promise.reject(error);
+        }
     );
     }
   

--- a/src/api/daily-api.ts
+++ b/src/api/daily-api.ts
@@ -11,9 +11,8 @@ export const getGameStatus = async (date: string, boardSize: number): Promise<Ga
     } catch (error) {
         if (error instanceof AxiosError) {
             const apiError = (error.response?.data as ApiResponse<unknown>)?.error;
-            toast.error(apiError?.message ?? "Something went wrong");
+            throw new Error(apiError?.message ?? "Something went wrong");
         }
-        console.error('Error fetching game settings:', error);
         throw error;
     }
 }

--- a/src/api/daily-api.ts
+++ b/src/api/daily-api.ts
@@ -1,16 +1,17 @@
 import { API_GAME_STATUS, API_HINT, API_CHECK_GUESS } from "@/constants";
 import { axiosSecure } from "./axios";
-import { checkGuessResponse, GameStatusResponse, getHintResponse } from "@/types";
+import { ApiResponse, checkGuessResponse, GameStatusResponse, getHintResponse } from "@/types";
 import { toast } from "react-toastify";
 import { AxiosError } from "axios";
-    
+
 export const getGameStatus = async (date: string, boardSize: number): Promise<GameStatusResponse> => {
     try {
-        const response = await axiosSecure.get(`${API_GAME_STATUS}?date=${date}&boardSize=${boardSize}`);
-        return response.data;
+        const response = await axiosSecure.get<ApiResponse<GameStatusResponse>>(`${API_GAME_STATUS}?date=${date}&boardSize=${boardSize}`);
+        return response.data.data!;
     } catch (error) {
-        if (error instanceof AxiosError && error.code === "ERR_BAD_RESPONSE") {
-            toast.error("Database is inactive, please ask developer to activate it");
+        if (error instanceof AxiosError) {
+            const apiError = (error.response?.data as ApiResponse<unknown>)?.error;
+            toast.error(apiError?.message ?? "Something went wrong");
         }
         console.error('Error fetching game settings:', error);
         throw error;
@@ -19,11 +20,12 @@ export const getGameStatus = async (date: string, boardSize: number): Promise<Ga
 
 export const getHint = async (puzzleId: number, x: number, y: number): Promise<getHintResponse> => {
     try {
-        const response = await axiosSecure.get(`${API_HINT}?puzzleId=${puzzleId}&x=${x}&y=${y}`);
-        return response.data;
+        const response = await axiosSecure.get<ApiResponse<getHintResponse>>(`${API_HINT}?puzzleId=${puzzleId}&x=${x}&y=${y}`);
+        return response.data.data!;
     } catch (error) {
-        if (error instanceof AxiosError && error.code === "ERR_BAD_RESPONSE") {
-            toast.error("Database is inactive, please ask developer to activate it");
+        if (error instanceof AxiosError) {
+            const apiError = (error.response?.data as ApiResponse<unknown>)?.error;
+            toast.error(apiError?.message ?? "Something went wrong");
         }
         console.error('Error fetching hint:', error);
         throw error;
@@ -32,11 +34,12 @@ export const getHint = async (puzzleId: number, x: number, y: number): Promise<g
 
 export const checkGuess = async (puzzleId: number, guess: string[][], attempts: number): Promise<checkGuessResponse> => {
     try {
-        const response = await axiosSecure.post(`${API_CHECK_GUESS}`, { puzzleId, guess, attempts });
-        return response.data;
+        const response = await axiosSecure.post<ApiResponse<checkGuessResponse>>(`${API_CHECK_GUESS}`, { puzzleId, guess, attempts });
+        return response.data.data!;
     } catch (error) {
-        if (error instanceof AxiosError && error.code === "ERR_BAD_RESPONSE") {
-            toast.error("Database is inactive, please ask developer to activate it");
+        if (error instanceof AxiosError) {
+            const apiError = (error.response?.data as ApiResponse<unknown>)?.error;
+            toast.error(apiError?.message ?? "Something went wrong");
         }
         console.error('Error checking guess:', error);
         throw error;

--- a/src/components/daily/daily.tsx
+++ b/src/components/daily/daily.tsx
@@ -1,5 +1,5 @@
 'use client'
-import React from 'react'
+import React, { useEffect } from 'react'
 import { Loader } from '@/components'
 import { useGameSettings } from '@/contexts'
 import {
@@ -23,10 +23,13 @@ function Daily() {
         setShowStatistics
     } = useGameLogic();
 
+    useEffect(() => {
+        if (error) {
+            toast.error(error.message || "Something went wrong");
+        }
+    }, [error]);
+
     console.log("settings in daily", settings)
-    if(error){
-        toast.error("Database is inactive, please ask developer to activate it");
-    }
     return (
         <div className='relative flex flex-col items-center w-full h-full overflow-hidden'>
             <GameHeader

--- a/src/constants/api/error-codes.ts
+++ b/src/constants/api/error-codes.ts
@@ -1,0 +1,15 @@
+export const ERROR_CODES = {
+    USER_NOT_FOUND: 1001,
+    PUZZLE_NOT_FOUND: 1002,
+    VALIDATION_ERROR: 1003,
+    INTERNAL_SERVER_ERROR: 1004,
+    USER_CREATION_FAILED: 1005,
+} as const;
+
+export const ERROR_MESSAGES: Record<number, string> = {
+    [ERROR_CODES.USER_NOT_FOUND]: "User not found",
+    [ERROR_CODES.PUZZLE_NOT_FOUND]: "Puzzle not found",
+    [ERROR_CODES.VALIDATION_ERROR]: "Validation failed",
+    [ERROR_CODES.INTERNAL_SERVER_ERROR]: "Internal server error",
+    [ERROR_CODES.USER_CREATION_FAILED]: "Failed to create user",
+};

--- a/src/constants/index.ts
+++ b/src/constants/index.ts
@@ -1,20 +1,23 @@
 import { API_NEW_USER, API_GAME_STATUS, API_HINT, API_CHECK_GUESS } from "./api/api-constants";
+import { ERROR_CODES, ERROR_MESSAGES } from "./api/error-codes";
 
 import { instructions } from "./help/instructions";
 
-import { 
-    DEFAULT_BOARD_SIZE, 
-    MAX_HINTS, 
+import {
+    DEFAULT_BOARD_SIZE,
+    MAX_HINTS,
     MAX_STARS,
     TILE_CORRECT_EMOJI,
     PUZZLE_START_DATE
 } from "./daily/game-constants";
 
-export { 
-    API_NEW_USER, 
-    API_GAME_STATUS, 
+export {
+    API_NEW_USER,
+    API_GAME_STATUS,
     API_HINT,
     API_CHECK_GUESS,
+    ERROR_CODES,
+    ERROR_MESSAGES,
     instructions,
     DEFAULT_BOARD_SIZE,
     MAX_HINTS,

--- a/src/types/api/daily-api.ts
+++ b/src/types/api/daily-api.ts
@@ -1,5 +1,15 @@
 import { StatisticsProps } from "../puzzle/puzzle";
 
+export interface ApiError {
+    code: number;
+    message: string;
+}
+
+export interface ApiResponse<T> {
+    data: T | null;
+    error?: ApiError;
+}
+
 export interface GameStatusResponse {
     hintCoordinates: { x: number, y: number, c: number }[];
     hintCount: number;

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -1,7 +1,9 @@
 export type {
     GameStatusResponse,
     getHintResponse,
-    checkGuessResponse
+    checkGuessResponse,
+    ApiError,
+    ApiResponse,
 } from "./api/daily-api";
 
 export type {


### PR DESCRIPTION
## Summary

- Add `ERROR_CODES` constants (1001–1005) and a shared `ApiResponse` interface so all routes return `{ data, error?: { code, message } }` --> (need more review attention on these error labels please)
- Update ALL 4 backend routes (`/puzzle/status`, `/puzzle/check`, `/puzzle/hint`, `/new-user`) to use the standard shape with correct HTTP status codes
- Update frontend to read actual error messages from the response instead of our hard coded strings - "Database is inactive..."

## Test plan

- [ ] Game loads normally when DB is active
- [ ] When DB is inactive, toast shows `"Internal server error"` (not the old string)
- [ ] Hint and guess flows still work correctly


Closes #36 