### PR TITLE
docs: unify package manager commands to use npm

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,7 +17,7 @@ cd Shabble
 
 ### Install Dependencies:
 ```
-pnpm install
+npm install
 ```
 
 ### Run Database Migrations:


### PR DESCRIPTION
Description:
This PR fixes an inconsistency in the setup instructions within the README. The guide previously instructed users to run pnpm install but then used npm for all subsequent commands (like npm run prisma:migrate and npm run dev). I updated the install command to npm install to ensure consistency and prevent potential lockfile conflicts for new contributors.

Closes #None